### PR TITLE
Add missing sinks spawn and spawnSync for shell injection

### DIFF
--- a/library/sinks/ChildProcess.test.ts
+++ b/library/sinks/ChildProcess.test.ts
@@ -38,7 +38,7 @@ t.test("it works", async (t) => {
 
   agent.start([new ChildProcess()]);
 
-  const { exec, execSync } = require("child_process");
+  const { exec, execSync, spawn, spawnSync } = require("child_process");
 
   const runCommandsWithInvalidArgs = () => {
     throws(
@@ -48,6 +48,16 @@ t.test("it works", async (t) => {
 
     throws(
       () => execSync(),
+      /argument must be of type string. Received undefined/
+    );
+
+    throws(
+      () => spawn().unref(),
+      /argument must be of type string. Received undefined/
+    );
+
+    throws(
+      () => spawnSync(),
       /argument must be of type string. Received undefined/
     );
   };
@@ -61,6 +71,8 @@ t.test("it works", async (t) => {
   const runSafeCommands = () => {
     exec("ls", (err, stdout, stderr) => {}).unref();
     execSync("ls", (err, stdout, stderr) => {});
+    spawn("ls", ["-la"], {}, (err, stdout, stderr) => {}).unref();
+    spawnSync("ls", ["-la"], {}, (err, stdout, stderr) => {});
   };
 
   runSafeCommands();
@@ -78,6 +90,18 @@ t.test("it works", async (t) => {
     throws(
       () => execSync("ls `echo .`", (err, stdout, stderr) => {}),
       "Aikido runtime has blocked a Shell injection: child_process.execSync(...) originating from body.file.matches"
+    );
+  });
+
+  runWithContext(unsafeContext, () => {
+    throws(
+      () => spawn("ls `echo .`", [], {shell: true}, (err, stdout, stderr) => {}).unref(),
+      "Aikido runtime has blocked a Shell injection: child_process.spawn(...) originating from body.file.matches"
+    );
+
+    throws(
+      () => spawnSync("ls `echo .`", [], {shell: true}, (err, stdout, stderr) => {}),
+      "Aikido runtime has blocked a Shell injection: child_process.spawnSync(...) originating from body.file.matches"
     );
   });
 });

--- a/library/sinks/ChildProcess.ts
+++ b/library/sinks/ChildProcess.ts
@@ -10,6 +10,17 @@ export class ChildProcess implements Wrapper {
     name: string,
     context: Context
   ): InterceptorResult {
+    // Ignore calls to spawn or spawnSync if shell option is not enabled
+    if (name === "spawn" || name === "spawnSync") {
+      const shellOption = args.find(
+        (arg) => typeof arg === "object" && arg !== null && "shell" in arg
+      );
+
+      if (!shellOption) {
+        return undefined;
+      }
+    }
+
     if (args.length > 0 && typeof args[0] === "string") {
       const command = args[0];
 
@@ -33,6 +44,12 @@ export class ChildProcess implements Wrapper {
       )
       .inspect("execSync", (args, subject, agent, context) =>
         this.inspectExec(args, "execSync", context)
+      )
+      .inspect("spawn", (args, subject, agent, context) =>
+        this.inspectExec(args, "spawn", context)
+      )
+      .inspect("spawnSync", (args, subject, agent, context) =>
+        this.inspectExec(args, "spawnSync", context)
       );
   }
 }


### PR DESCRIPTION
This PR adds the missing sinks `spawn` and `spawnAsync` for shell injection, and ensures that we only inspect the call if the `shell` option is `true` (by default, this is false in Node).

Additional information: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options