### PR TITLE
Add unlink to list of sinks/calls we need to hook for path traversal

### DIFF
--- a/library/sinks/FileSystem.ts
+++ b/library/sinks/FileSystem.ts
@@ -23,6 +23,7 @@ const functionsWithPath = [
   "readdir",
   "readFile",
   "readlink",
+  "unlink",
   "realpath",
   "rename",
   "rmdir",


### PR DESCRIPTION
See: https://nodejs.org/api/fs.html#fsunlinkpath-callback. `unlink` either removes a file or symbolic link (depending on the file).