### PR TITLE
Fix detection of injection in spawn arguments

### DIFF
--- a/library/sinks/ChildProcess.test.ts
+++ b/library/sinks/ChildProcess.test.ts
@@ -114,8 +114,8 @@ t.test("it works", async (t) => {
     throws(
       () =>
         spawn(
-          "ls `echo .`",
-          [],
+          "ls",
+          ["`echo .`"],
           { shell: "/bin/sh" },
           (err, stdout, stderr) => {}
         ).unref(),

--- a/library/sinks/ChildProcess.ts
+++ b/library/sinks/ChildProcess.ts
@@ -33,7 +33,8 @@ export class ChildProcess implements Wrapper {
       if (
         (name === "spawn" || name === "spawnSync") &&
         args.length > 1 &&
-        Array.isArray(args[1])
+        Array.isArray(args[1]) &&
+        args[1].length > 0
       ) {
         command += " " + args[1].join(" ");
       }

--- a/library/sinks/ChildProcess.ts
+++ b/library/sinks/ChildProcess.ts
@@ -28,7 +28,15 @@ export class ChildProcess implements Wrapper {
     }
 
     if (args.length > 0 && typeof args[0] === "string") {
-      const command = args[0];
+      let command = args[0];
+
+      if (
+        (name === "spawn" || name === "spawnSync") &&
+        args.length > 1 &&
+        Array.isArray(args[1])
+      ) {
+        command += " " + args[1].join(" ");
+      }
 
       return checkContextForShellInjection({
         command: command,


### PR DESCRIPTION
Command arguments passed as an array using `spawn` or `spawnSync` were not checked for command injection.

```ts
spawn('checked', ['not checked'], { shell: true });
```